### PR TITLE
doc(readme.md): fix method http for get all result and change path fo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ project_id | Yes | Provide Project ID
 ```shell
 
 curl http://localhost:8000/api/webscanresult/ \
-    -X POST \
+    -X GET \
     -H "Content-Type: application/json" \
     -H "Authorization: JWT token" \
     -d '{"scan_id":"a20b9c2e-1bd0-4a69-8771-67c023a3b96b"}'
@@ -321,7 +321,7 @@ This endpoint retrieves vulnerability data for particular web scan. Archery perf
 
 ### HTTP Request
 
-`POST http://localhost:8000/api/webscanresult/`
+`GET http://localhost:8000/api/webscanresult/`
 
 ### URL Parameters
 
@@ -383,7 +383,7 @@ This endpoint retrieves all network scan results. Archery performing network and
 
 ### HTTP Request
 
-`GET http://localhost:8000/api/webscan/`
+`GET http://localhost:8000/api/networkscan/`
 
 ## Scan Launch  
 
@@ -429,7 +429,7 @@ project_id | Yes | Provide Project ID
 ```shell
 
 curl http://localhost:8000/api/networkscanresult/ \
-    -X POST \
+    -X GET \
     -H "Content-Type: application/json" \
     -H "Authorization: JWT token" \
     -d '{"scan_id":"a20b9c2e-1bd0-4a69-8771-67c023a3b96b"}'
@@ -515,7 +515,7 @@ This endpoint retrieves vulnerability data for particular Network scan. Archery 
 
 ### HTTP Request
 
-`POST http://localhost:8000/api/networkscanresult/`
+`GET http://localhost:8000/api/networkscanresult/`
 
 ### URL Parameters
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -259,13 +259,14 @@ project_id | Yes | Provide Project ID
 scanner | Yes | Provide scanner 
         |     |                 OWASP ZAP Scanner - zap_scan
         |     |                 Burp Scanner - burp_scan
+        |     |                 Arachni - arachni
 
 ## Get Scan Results
 
 ```shell
 
 curl http://localhost:8000/api/webscanresult/ \
-    -X POST \
+    -X GET \
     -H "Content-Type: application/json" \
     -H "Authorization: JWT token" \
     -d '{"scan_id":"a20b9c2e-1bd0-4a69-8771-67c023a3b96b"}'
@@ -324,7 +325,7 @@ This endpoint retrieves vulnerability data for particular web scan. Archery perf
 
 ### HTTP Request
 
-`POST http://localhost:8000/api/webscanresult/`
+`GET http://localhost:8000/api/webscanresult/`
 
 ### URL Parameters
 
@@ -386,7 +387,7 @@ This endpoint retrieves all network scan results. Archery performing network and
 
 ### HTTP Request
 
-`GET http://localhost:8000/api/webscan/`
+`GET http://localhost:8000/api/networkscan/`
 
 ## Scan Launch  
 
@@ -432,7 +433,7 @@ project_id | Yes | Provide Project ID
 ```shell
 
 curl http://localhost:8000/api/networkscanresult/ \
-    -X POST \
+    -X GET \
     -H "Content-Type: application/json" \
     -H "Authorization: JWT token" \
     -d '{"scan_id":"a20b9c2e-1bd0-4a69-8771-67c023a3b96b"}'
@@ -518,7 +519,7 @@ This endpoint retrieves vulnerability data for particular Network scan. Archery 
 
 ### HTTP Request
 
-`POST http://localhost:8000/api/networkscanresult/`
+`GET http://localhost:8000/api/networkscanresult/`
 
 ### URL Parameters
 


### PR DESCRIPTION
Hi,

I want to propose you a fix for api-docs :

So i explain, in this documentation this things are bad:

POST http://localhost:8000/api/webscanresult/ is not a POST method but GET http method

idem for:

POST http://localhost:8000/api/networkscanresult/ is not a POST method but GET http method for get scan result.

then in NetworkScan item, this URL is not correct:

GET http://localhost:8000/api/webscan/ but this must be GET http://localhost:8000/api/networkscan/

And i have add arachni scan options in option for launch webscan with arachni.

Enjoy, Grounz